### PR TITLE
Ensure IsolationPlayer cannot be instantiated

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Udacity, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ The following example creates a game and illustrates the basic API.  You can run
 
 ### Coding
 
-The steps below outline a suggested process for completing the project -- however, this is just a suggestion to help you get started.  A stub for writing unit tests is provided in the `agent_test.py` file (no local test cases are provided). (See the [unittest](https://docs.python.org/3/library/unittest.html#basic-example) module for information on getting started.)
+The steps below outline a suggested process for completing the project -- however, this is just a suggestion to help you get started.
+
+A stub for writing unit tests is provided in the [`test_game_agent.py`](tests/test_game_agent.py) file (no local test cases are provided). In order to run your tests, execute `python -m unittest` command (See the [unittest](https://docs.python.org/3/library/unittest.html#basic-example) module for information on getting started.)
 
 The primary mechanism for testing your code will be the Udacity Project Assistant command line utility.  You can install the Udacity-PA tool by activating your aind anaconda environment, then running `pip install udacity-pa`.  You can submit your code for scoring by running `udacity submit isolation`.  The project assistant server has a collection of unit tests that it will execute on your code, and it will provide feedback on any successes or failures.  You must pass all test cases in the project assistant before you can complete the project by submitting your report for review.
 

--- a/game_agent.py
+++ b/game_agent.py
@@ -21,17 +21,17 @@ def custom_score(game, player):
 
     Parameters
     ----------
-    game : `isolation.Board`
+    game : isolation.Board
         An instance of `isolation.Board` encoding the current state of the
         game (e.g., player locations and blocked cells).
 
-    player : object
+    player : IsolationPlayer
         A player instance in the current game (i.e., an object corresponding to
-        one of the player objects `game.__player_1__` or `game.__player_2__`.)
+        one of the player objects `game.__player_1__` or `game.__player_2__`).
 
     Returns
     -------
-    float
+    value: float
         The heuristic value of the current game state to the specified player.
     """
     # TODO: finish this function!
@@ -47,17 +47,17 @@ def custom_score_2(game, player):
 
     Parameters
     ----------
-    game : `isolation.Board`
+    game : isolation.Board
         An instance of `isolation.Board` encoding the current state of the
         game (e.g., player locations and blocked cells).
 
-    player : object
+    player : IsolationPlayer
         A player instance in the current game (i.e., an object corresponding to
-        one of the player objects `game.__player_1__` or `game.__player_2__`.)
+        one of the player objects `game.__player_1__` or `game.__player_2__`).
 
     Returns
     -------
-    float
+    value: float
         The heuristic value of the current game state to the specified player.
     """
     # TODO: finish this function!
@@ -79,7 +79,7 @@ def custom_score_3(game, player):
 
     player : object
         A player instance in the current game (i.e., an object corresponding to
-        one of the player objects `game.__player_1__` or `game.__player_2__`.)
+        one of the player objects `game.__player_1__` or `game.__player_2__`).
 
     Returns
     -------
@@ -90,29 +90,45 @@ def custom_score_3(game, player):
     raise NotImplementedError
 
 
-class IsolationPlayer:
-    """Base class for minimax and alphabeta agents -- this class is never
-    constructed or tested directly.
+class IsolationPlayer(ABC):
+    """Base class for minimax and alpha-beta agents.
 
-    ********************  DO NOT MODIFY THIS CLASS  ********************
-
-    Parameters
+    Attributes
     ----------
-    search_depth : int (optional)
-        A strictly positive integer (i.e., 1, 2, 3,...) for the number of
-        layers in the game tree to explore for fixed-depth search. (i.e., a
-        depth of one (1) would only explore the immediate sucessors of the
-        current state.)
+    search_depth : int
+        Depth limit of player agent search
 
-    score_fn : callable (optional)
-        A function to use for heuristic evaluation of game states.
+    score : callable
+        Function to calculate score over remaining legal moves
 
-    timeout : float (optional)
-        Time remaining (in milliseconds) when search is aborted. Should be a
-        positive value large enough to allow the function to return before the
-        timer expires.
+    time_left : int
+        Remaining time to player search for a solution
+
+    TIMER_THRESHOLD: float
+        Time threshold when the player should stop
     """
+
     def __init__(self, search_depth=3, score_fn=custom_score, timeout=10.):
+        """IsolationPlayer abstract constructor
+
+        Abstract construct ensuring class is never constructed/tested directly
+
+        Parameters
+        ----------
+        search_depth : int, optional
+            A strictly positive integer (i.e., 1, 2, 3,...) for the number of
+            layers in the game tree to explore for fixed-depth search. (i.e., a
+            depth of one (1) would only explore the immediate successors of the
+            current state.)
+
+        score_fn : callable, optional
+            A function to use for heuristic evaluation of game states.
+
+        timeout : float, optional
+            Time remaining (in milliseconds) when search is aborted. Should be a
+            positive value large enough to allow the function to return before the
+            timer expires.
+        """
         self.search_depth = search_depth
         self.score = score_fn
         self.time_left = None
@@ -120,16 +136,15 @@ class IsolationPlayer:
 
 
 class MinimaxPlayer(IsolationPlayer):
-    """Game-playing agent that chooses a move using depth-limited minimax
+    """Agent powered by depth-limited minimax search
+
+    Game-playing agent that chooses a move using depth-limited minimax
     search. You must finish and test this player to make sure it properly uses
     minimax to return a good move before the search time limit expires.
     """
 
     def get_move(self, game, time_left):
-        """Search for the best move from the available legal moves and return a
-        result before the time limit expires.
-
-        **************  YOU DO NOT NEED TO MODIFY THIS FUNCTION  *************
+        """Get next best legal move before timeout expires
 
         For fixed-depth search, this function simply wraps the call to the
         minimax method, but this method provides a common interface for all
@@ -138,7 +153,7 @@ class MinimaxPlayer(IsolationPlayer):
 
         Parameters
         ----------
-        game : `isolation.Board`
+        game : isolation.Board
             An instance of `isolation.Board` encoding the current state of the
             game (e.g., player locations and blocked cells).
 
@@ -149,9 +164,10 @@ class MinimaxPlayer(IsolationPlayer):
 
         Returns
         -------
-        (int, int)
+        move : (int, int)
             Board coordinates corresponding to a legal move; may return
             (-1, -1) if there are no available legal moves.
+
         """
         self.time_left = time_left
 
@@ -194,7 +210,7 @@ class MinimaxPlayer(IsolationPlayer):
 
         Returns
         -------
-        (int, int)
+        move : (int, int)
             The board coordinates of the best move found in the current search;
             (-1, -1) if there are no legal moves
 
@@ -217,27 +233,22 @@ class MinimaxPlayer(IsolationPlayer):
 
 
 class AlphaBetaPlayer(IsolationPlayer):
-    """Game-playing agent that chooses a move using iterative deepening minimax
+    """Agent powered by iterative deepening and alpha-beta pruning search
+
+    Game-playing agent that chooses a move using iterative deepening minimax
     search with alpha-beta pruning. You must finish and test this player to
     make sure it returns a good move before the search time limit expires.
     """
 
     def get_move(self, game, time_left):
-        """Search for the best move from the available legal moves and return a
+        """Get next best legal move before timeout expires
+
+        Search for the best move from the available legal moves and return a
         result before the time limit expires.
-
-        Modify the get_move() method from the MinimaxPlayer class to implement
-        iterative deepening search instead of fixed-depth search.
-
-        **********************************************************************
-        NOTE: If time_left() < 0 when this function returns, the agent will
-              forfeit the game due to timeout. You must return _before_ the
-              timer reaches 0.
-        **********************************************************************
 
         Parameters
         ----------
-        game : `isolation.Board`
+        game : isolation.Board
             An instance of `isolation.Board` encoding the current state of the
             game (e.g., player locations and blocked cells).
 
@@ -248,16 +259,17 @@ class AlphaBetaPlayer(IsolationPlayer):
 
         Returns
         -------
-        (int, int)
+        move : (int, int)
             Board coordinates corresponding to a legal move; may return
             (-1, -1) if there are no available legal moves.
+
         """
         self.time_left = time_left
 
         # TODO: finish this function!
         raise NotImplementedError
 
-    def alphabeta(self, game, depth, alpha=float("-inf"), beta=float("inf")):
+    def alpha_beta(self, game, depth, alpha=float("-inf"), beta=float("inf")):
         """Implement depth-limited minimax search with alpha-beta pruning as
         described in the lectures.
 
@@ -287,7 +299,7 @@ class AlphaBetaPlayer(IsolationPlayer):
 
         Returns
         -------
-        (int, int)
+        move : (int, int)
             The board coordinates of the best move found in the current search;
             (-1, -1) if there are no legal moves
 

--- a/game_agent.py
+++ b/game_agent.py
@@ -4,6 +4,8 @@ and include the results in your report.
 """
 import random
 
+from abc import ABC, abstractmethod
+
 
 class SearchTimeout(Exception):
     """Subclass base exception for code clarity. """
@@ -108,6 +110,7 @@ class IsolationPlayer(ABC):
         Time threshold when the player should stop
     """
 
+    @abstractmethod
     def __init__(self, search_depth=3, score_fn=custom_score, timeout=10.):
         """IsolationPlayer abstract constructor
 
@@ -134,6 +137,33 @@ class IsolationPlayer(ABC):
         self.time_left = None
         self.TIMER_THRESHOLD = timeout
 
+    @abstractmethod
+    def get_move(self, game, time_left):
+        """Get next best legal move before timeout expires
+
+        Search for the best move from the available legal moves and return a
+        result before the time limit expires.
+
+        Parameters
+        ----------
+        game: isolation.Board
+            An instance of `isolation.Board` encoding the current state of the
+            game (e.g., player locations and blocked cells).
+
+        time_left: callable
+            A function that returns the number of milliseconds left in the
+            current turn. Returning with any less than 0 ms remaining forfeits
+            the game.
+
+        Returns
+        -------
+        move : (int, int)
+            Board coordinates corresponding to a legal move; may return
+            (-1, -1) if there are no available legal moves.
+
+        """
+        raise NotImplementedError
+
 
 class MinimaxPlayer(IsolationPlayer):
     """Agent powered by depth-limited minimax search
@@ -142,6 +172,9 @@ class MinimaxPlayer(IsolationPlayer):
     search. You must finish and test this player to make sure it properly uses
     minimax to return a good move before the search time limit expires.
     """
+
+    def __init__(self, search_depth, score_fn, timeout):
+        super().__init__(search_depth, score_fn, timeout)
 
     def get_move(self, game, time_left):
         """Get next best legal move before timeout expires
@@ -239,6 +272,9 @@ class AlphaBetaPlayer(IsolationPlayer):
     search with alpha-beta pruning. You must finish and test this player to
     make sure it returns a good move before the search time limit expires.
     """
+
+    def __init__(self, search_depth, score_fn, timeout):
+        super().__init__(search_depth, score_fn, timeout)
 
     def get_move(self, game, time_left):
         """Get next best legal move before timeout expires

--- a/tests/test_game_agent.py
+++ b/tests/test_game_agent.py
@@ -20,6 +20,10 @@ class IsolationTest(unittest.TestCase):
         self.player2 = "Player2"
         self.game = isolation.Board(self.player1, self.player2)
 
+    def test_example(self):
+        # TODO: All methods must start with "test_"
+        self.fail("Hello, World!")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tournament.py
+++ b/tournament.py
@@ -120,7 +120,7 @@ def play_matches(cpu_agents, test_agents, num_matches):
                "increasing the timeout margin for your agent.\n").format(
             total_timeouts))
     if total_forfeits:
-        print(("\nYour ID search forfeited {} games while there were still " +
+        print(("\nYour agents forfeited {} games while there were still " +
                "legal moves available to play.\n").format(total_forfeits))
 
 


### PR DESCRIPTION
Description
---------------
Use abstract base class is the pythonic way of ensure `IsolationPlayer` cannot be constructed/tested directly, but only through its subclasses.

References
---------------

  - [Python 3 Documentation - Abstract Base Class](https://docs.python.org/3/library/abc.html)
  - [The Hichhiker's Guide to Python - Documentation](http://docs.python-guide.org/en/latest/writing/documentation/)
     